### PR TITLE
feat: given a configuration file, run defined modules

### DIFF
--- a/configs/maddock.yml
+++ b/configs/maddock.yml
@@ -1,6 +1,6 @@
 vcsPollDelay: 5s
 
 vcs:
-  uri: file:///home/madjlzz/Projects/maddock/test/cfg-repo
+  uri: file:///home/jklaer/Projects/sandbox/maddock/test/cfg-repo
   ref: main
   destination: /tmp/maddock-cfg

--- a/examples/kernel_parameter_recipe.yml
+++ b/examples/kernel_parameter_recipe.yml
@@ -1,2 +1,3 @@
 kernel_parameters:
   - fs/inotify/max_user_instances: 129
+  - debug/exception-trace: 0

--- a/examples/kernel_parameter_recipe.yml
+++ b/examples/kernel_parameter_recipe.yml
@@ -1,0 +1,2 @@
+kernel_parameters:
+  - fs/inotify/max_user_instances: 129

--- a/internal/modules/kernel.go
+++ b/internal/modules/kernel.go
@@ -48,10 +48,7 @@ func (k *KernelParameterModule) Base64Encode() string {
 
 func (k *KernelParameterModule) Dirty() bool {
 	stateHash := k.stateService.Get("kernel_module")
-	if stateHash != k.Base64Encode() {
-		return true
-	}
-	return false
+	return stateHash != k.Base64Encode()
 }
 
 func (k *KernelParameterModule) Do() error {

--- a/internal/recipe/parser.go
+++ b/internal/recipe/parser.go
@@ -1,0 +1,68 @@
+package recipe
+
+import (
+	"fmt"
+	"github.com/MadJlzz/maddock/internal/modules"
+	"gopkg.in/yaml.v3"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type Recipe struct {
+	Modules []modules.Module
+	//Modules struct {
+	//	KernelParameterModule modules.Module `yaml:"kernel_parameters"`
+	//}
+}
+
+func DiscoverRecipes(sourcePath string) {
+	var recipesFilepath []string
+	err := filepath.WalkDir(sourcePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return err
+		}
+		if !d.IsDir() {
+			fmt.Printf("visited file or dir: %q\n", path)
+			recipesFilepath = append(recipesFilepath, path)
+
+			var recipe Recipe
+			fd, _ := os.ReadFile(path)
+			err = yaml.Unmarshal(fd, &recipe)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println(recipe)
+
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Printf("error walking the path %q: %v\n", sourcePath, err)
+		return
+	}
+}
+
+type tmpRecipe struct {
+	KPM []yaml.Node `yaml:"kernel_parameters"`
+}
+
+func (r *Recipe) UnmarshalYAML(value *yaml.Node) error {
+	var tmp tmpRecipe
+	if err := value.Decode(&tmp); err != nil {
+		return err
+	}
+	var kernelParameters []modules.KernelParameter
+	for _, i := range tmp.KPM {
+		kp := modules.KernelParameter{
+			Key:   i.Content[0].Value,
+			Value: i.Content[1].Value,
+		}
+		kernelParameters = append(kernelParameters, kp)
+	}
+
+	r.Modules = append(r.Modules, modules.NewKernelModule(kernelParameters))
+
+	return nil
+}

--- a/internal/recipe/parser.go
+++ b/internal/recipe/parser.go
@@ -5,7 +5,6 @@ import (
 	"github.com/MadJlzz/maddock/internal/modules"
 	"gopkg.in/yaml.v3"
 	"io/fs"
-	"os"
 	"path/filepath"
 )
 
@@ -13,32 +12,24 @@ type Recipe struct {
 	Modules []modules.Module
 }
 
-func DiscoverRecipes(sourcePath string) {
+func DiscoverRecipes(sourcePath string) []string {
 	var recipesFilepath []string
 	err := filepath.WalkDir(sourcePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
 			return err
 		}
-		if !d.IsDir() {
+		if !d.IsDir() && filepath.Ext(d.Name()) == ".yml" {
 			fmt.Printf("visited file or dir: %q\n", path)
 			recipesFilepath = append(recipesFilepath, path)
-
-			var recipe Recipe
-			fd, _ := os.ReadFile(path)
-			err = yaml.Unmarshal(fd, &recipe)
-			if err != nil {
-				panic(err)
-			}
-			fmt.Println(recipe)
-
 		}
 		return nil
 	})
 	if err != nil {
 		fmt.Printf("error walking the path %q: %v\n", sourcePath, err)
-		return
+		return nil
 	}
+	return recipesFilepath
 }
 
 type tmpRecipe struct {

--- a/internal/recipe/parser.go
+++ b/internal/recipe/parser.go
@@ -11,9 +11,6 @@ import (
 
 type Recipe struct {
 	Modules []modules.Module
-	//Modules struct {
-	//	KernelParameterModule modules.Module `yaml:"kernel_parameters"`
-	//}
 }
 
 func DiscoverRecipes(sourcePath string) {
@@ -45,7 +42,7 @@ func DiscoverRecipes(sourcePath string) {
 }
 
 type tmpRecipe struct {
-	KPM []yaml.Node `yaml:"kernel_parameters"`
+	KPM modules.KernelParameterModule `yaml:"kernel_parameters"`
 }
 
 func (r *Recipe) UnmarshalYAML(value *yaml.Node) error {
@@ -53,16 +50,6 @@ func (r *Recipe) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&tmp); err != nil {
 		return err
 	}
-	var kernelParameters []modules.KernelParameter
-	for _, i := range tmp.KPM {
-		kp := modules.KernelParameter{
-			Key:   i.Content[0].Value,
-			Value: i.Content[1].Value,
-		}
-		kernelParameters = append(kernelParameters, kp)
-	}
-
-	r.Modules = append(r.Modules, modules.NewKernelModule(kernelParameters))
-
+	r.Modules = append(r.Modules, &tmp.KPM)
 	return nil
 }

--- a/internal/state/service.go
+++ b/internal/state/service.go
@@ -13,7 +13,7 @@ func NewStateService(storageType StorageType) *Service {
 	return &Service{backend: backend}
 }
 
-func (ss *Service) Get(moduleName string) []string {
+func (ss *Service) Get(moduleName string) string {
 	return ss.backend.Get(moduleName)
 }
 

--- a/internal/state/storage.go
+++ b/internal/state/storage.go
@@ -7,30 +7,30 @@ const (
 )
 
 type Storage interface {
-	Get(moduleName string) []string
+	Get(moduleName string) string
 	Insert(moduleName string, hash string)
 }
 
 type inMemory struct {
 	// Will probably need some mutex locks in some sort.
-	data map[string][]string
+	data map[string]string
 }
 
 func newInMemory() *inMemory {
 	return &inMemory{
-		data: map[string][]string{
-			"kernel_module": {},
+		data: map[string]string{
+			"kernel_module": "",
 		},
 	}
 }
 
-func (im *inMemory) Get(moduleName string) []string {
+func (im *inMemory) Get(moduleName string) string {
 	if _, exists := im.data[moduleName]; !exists {
-		return []string{}
+		return ""
 	}
 	return im.data[moduleName]
 }
 
 func (im *inMemory) Insert(moduleName string, hash string) {
-	im.data[moduleName] = append(im.data[moduleName], hash)
+	im.data[moduleName] = hash
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"github.com/MadJlzz/maddock/internal/core"
+	"github.com/MadJlzz/maddock/internal/recipe"
 	"log"
 	"os"
 	"os/signal"
@@ -22,5 +24,9 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	agent.Start(ctx)
+	fmt.Println(agent, ctx)
+
+	recipe.DiscoverRecipes("examples")
+
+	//agent.Start(ctx)
 }

--- a/main.go
+++ b/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/MadJlzz/maddock/internal/core"
-	"github.com/MadJlzz/maddock/internal/recipe"
 	"log"
 	"os"
 	"os/signal"
@@ -24,9 +22,5 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	fmt.Println(agent, ctx)
-
-	recipe.DiscoverRecipes("examples")
-
-	//agent.Start(ctx)
+	agent.Start(ctx)
 }


### PR DESCRIPTION
- [x] **feature:** unmarshaling YAML to recipe struct
- [x] **fix:** missing `git fetch` to get latest references before hard reset to the ref of the agent configuration
- [x] **feature:** find recipes (yaml) in the VCS repository every time we poll
- [x] **feature:** upon each poll, check if the module state changed, and if so rerun it (only for the first defined module atm)